### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,4 +1,6 @@
 name: .NET
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/majorsilence/Majorsilence.BearerTokenGenerator/security/code-scanning/3](https://github.com/majorsilence/Majorsilence.BearerTokenGenerator/security/code-scanning/3)

In general, fix this by adding an explicit `permissions:` block that restricts the `GITHUB_TOKEN` to the minimal required scope. For this workflow, the jobs only need to read repository contents to allow `actions/checkout` to function; no job performs operations requiring write access or other scopes.

The best fix without changing existing functionality is to add a workflow‑level `permissions:` block directly under the `name: .NET` line, setting `contents: read`. This will apply to all jobs (`linux-build`, `windows-build`, `mac-build`) since none of them define their own `permissions:`. No other changes, imports, or additional configuration are needed. The rest of the YAML remains as is.

Concretely, in `.github/workflows/dotnet.yml`, modify the top of the file (around lines 1–4) to insert:

```yaml
name: .NET
permissions:
  contents: read

on:
  push:
    branches: [ main ]
  ...
```

This explicitly limits the `GITHUB_TOKEN` for all jobs to read‑only access to repository contents, satisfying CodeQL’s recommendation and GitHub’s least‑privilege guidance.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
